### PR TITLE
Get CMake interface target information

### DIFF
--- a/meta_dds/cli.py
+++ b/meta_dds/cli.py
@@ -31,6 +31,11 @@ def project(parser: ArgumentParser):
                         help='The project to build. Default: the current working directory.')
 
 
+def scratch_dir(parser: ArgumentParser):
+    parser.add_argument('--scratch-dir', type=Path, default=None,
+                        help='Do the work in the specified scratch directory rather than a temporary directory. This is for debugging purposes.')
+
+
 def output(parser: ArgumentParser):
     parser.add_argument('-o', '--out', '--output', type=Path, default=Path.cwd() / '_build',
                         dest='output', help=f"Directory where dds will write build results. Default: `./_build'.")

--- a/meta_dds/cmake.py
+++ b/meta_dds/cmake.py
@@ -262,7 +262,6 @@ def setup_parser(parser: ArgumentParser):
             cmake_exe = dataclasses.replace(exes.cmake, source_dir=args.project, build_dir=f)
             print(query_cmake_target(cmake_exe, toolchain.get_dds_toolchain(args.toolchain), args.target))
     cmake_query_target.set_defaults(func=query)
-    cli.add_arguments(cmake_query_target, cli.project, cli.toolchain)
+    cli.add_arguments(cmake_query_target, cli.project, cli.toolchain, cli.scratch_dir)
     cmake_query_target.add_argument('--target', help='', required=True)
-    cmake_query_target.add_argument('--scratch-dir', type=Path, required=True)
     # TODO: Full CMake project sdist porter subcommand. A command that has none of this meta-sdist stuff.

--- a/meta_dds/cmake.py
+++ b/meta_dds/cmake.py
@@ -138,6 +138,8 @@ class CMakeTargetInfo:
     public_dependencies: List[str] = field(default_factory=list)
     dependencies: List[str] = field(default_factory=list)
 
+    is_imported: bool = False
+
 def query_cmake_target(cmake: CMake, toolchain, target: str) -> CMakeTargetInfo:
     result = CMakeTargetInfo()
     PROPERTIES = {
@@ -149,6 +151,7 @@ def query_cmake_target(cmake: CMake, toolchain, target: str) -> CMakeTargetInfo:
         'COMPILE_DEFINITIONS': result.preprocessor_defines,
         'LINK_LIBRARIES': result.dependencies,
         'INTERFACE_LINK_LIBRARIES': result.public_dependencies,
+        'IMPORTED': result.is_imported,
     }
     from meta_dds import toolchain as tc
     cmake_toolchain_contents: str = tc.generate_toolchain(toolchain)
@@ -211,6 +214,7 @@ def query_cmake_target(cmake: CMake, toolchain, target: str) -> CMakeTargetInfo:
         source_files=[Path(x) for x in set(result.source_files)],
         public_dependencies=[x for x in set(result.public_dependencies) if '/' not in x and '.' not in x],
         dependencies=[x for x in set(result.dependencies) if '/' not in x and '.' not in x],
+        is_imported=bool(result.is_imported),
     )
 
 

--- a/meta_dds/cmake_forge_sdist.py
+++ b/meta_dds/cmake_forge_sdist.py
@@ -42,8 +42,6 @@ def forge_main(args: Namespace):
 
 def setup_parser(parser: ArgumentParser):
     cli.add_arguments(parser, cli.toolchain, cli.project,
-                      cli.output, cli.cmake_meta_info)
+                      cli.output, cli.cmake_meta_info, cli.scratch_dir)
     cli.if_exists(parser, help='What to do if the sdist tar.gz already exists')
-    parser.add_argument('--scratch-dir', type=Path, default=None,
-                        help='Path to configure as a CMake build directory in the process of forging an sdist')
     parser.set_defaults(func=forge_main)

--- a/meta_dds/tempfiles.py
+++ b/meta_dds/tempfiles.py
@@ -35,3 +35,10 @@ def TemporaryDirectory(scratch_dir=None, **kwargs):
         with tempfile.TemporaryDirectory(**kwargs) as f:
             yield Path(f)
 
+@contextmanager
+def TemporaryFile(**kwargs):
+    if 'prefix' not in kwargs:
+        kwargs['prefix'] = 'meta-dds-f-'
+
+    with tempfile.NamedTemporaryFile(**kwargs) as f:
+        yield Path(f.name)


### PR DESCRIPTION
The file api doesn't work for interface targets (ugh). So we need to obtain that information through other means, e.g. by reading the properties off of the CMake targets.

Concerns:
 - What about when projects have a lot of libraries linked together?